### PR TITLE
Add support for multipart messages with 16-bit references

### DIFF
--- a/src/TinySMS.h
+++ b/src/TinySMS.h
@@ -11,7 +11,7 @@ public:
     String sender;
     String message;
     String date;
-    char ref;
+    uint16_t ref;
     uint8_t part = 1;
     uint8_t totalParts = 1;
 };

--- a/src/functions.tpp
+++ b/src/functions.tpp
@@ -105,6 +105,14 @@ SMS TinySMS::parsePDU(String data)
         sms.part = strtol(pdu.substring(10, 12).c_str(), NULL, 16);
         message = decodeUnicode(pdu.substring(12));
     }
+    else if (pdu.substring(0, 6) == "060804")
+    {
+        // multipart with 16-bit reference
+        sms.ref = strtol(pdu.substring(6, 10).c_str(), NULL, 16);
+        sms.totalParts = strtol(pdu.substring(10, 12).c_str(), NULL, 16);
+        sms.part = strtol(pdu.substring(12, 14).c_str(), NULL, 16);
+        message = decodeUnicode(pdu.substring(14));
+    }
     else
         message = decodeUnicode(pdu);
 


### PR DESCRIPTION
I realized the library doesn't support PDUs for multipart SMS with 16-bit reference. This small patch will add the support. The code is tested on sample PDUs received. Before this patch, the sample PDUs weren't correctly decoded, after the patch, they are correctly decoded.